### PR TITLE
Upgrade docker-run action to v3

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -184,7 +184,7 @@ jobs:
         with:
           repository: 'wasmerio/wasmer'
           ref: 'master'
-      - uses: addnab/docker-run-action@v1
+      - uses: addnab/docker-run-action@v3
         with:
           image: ${{ matrix.image }}
           options: -v ${{ github.workspace }}:/work


### PR DESCRIPTION
https://github.com/wasmerio/wasmer/pull/2242 but for wasmer-nightly. Bors isn't running there for some reason, so trying to debug it here.